### PR TITLE
ci: Fix wiki update error in deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,4 +121,5 @@ jobs:
           git config --local user.name "${GIT_CONFIG_USER}"
           git add ${{ matrix.ros-distro }}.md
           git commit -m "Update ${{ matrix.ros-distro }}.md"
-          git push origin master
+          git fetch origin && git merge origin/master --no-edit && git push origin master || \
+          git fetch origin && git merge origin/master --no-edit && git push origin master


### PR DESCRIPTION
In some cases, GitHub Actions fails to update the wiki and the docker image update itself stops. This will be improved.

![Screenshot from 2022-02-20 22-49-46](https://user-images.githubusercontent.com/3256629/154845790-7c3c4759-8ef9-42ad-bc1f-87d432d3c885.png)
