### PR TITLE
feat: Create user even if home directory is mounted

### DIFF
--- a/foxy/ros_entrypoint.sh
+++ b/foxy/ros_entrypoint.sh
@@ -5,6 +5,7 @@ DEFAULT_USER=${DEFAULT_USER:-'ubuntu'}
 DEFAULT_USER_UID=${USER_UID:-'1000'}
 DEFAULT_USER_GID=${USER_GID:-'1000'}
 NOPASSWD=${NOPASSWD:-''} # set 'NOPASSWD:' to disable asking sudo password
+SHELL=${DEFAULT_SHELL:-$SHELL}
 
 if [[ $(id -u) -eq 0 ]]; then
 	echo "Set disable_coredump false" >> /etc/sudo.conf
@@ -21,8 +22,9 @@ fi
 if [[ $(id -u) -eq 0 ]]; then
 	EXEC="exec /sbin/su-exec ${DEFAULT_USER}"
 
-	# create_user
-	if [[ ! -e /home/${DEFAULT_USER} ]]; then
+	# if the user does not exist, create user
+	if [[ $(id -u ${DEFAULT_USER} 2> /dev/null) != ${DEFAULT_USER_UID} ]]; then
+		echo creating user ${DEFAULT_USER}
 		groupadd -g "${DEFAULT_USER_GID}" "${DEFAULT_USER}"
 		useradd --create-home --home-dir /home/${DEFAULT_USER} --uid ${DEFAULT_USER_UID} --shell /bin/bash \
 		    --gid ${DEFAULT_USER_GID} --groups sudo ${DEFAULT_USER}
@@ -44,14 +46,20 @@ if [[ $(id -u) -eq 0 ]]; then
 
 	DEFAULT_USER_UID="$(${EXEC} id -u)"
 	DEFAULT_USER_GID="$(${EXEC} id -g)"
+	HOME="/home/${DEFAULT_USER}"
 else # use existing user
 	EXEC="exec"
 	DEFAULT_USER="$(whoami)"
 	DEFAULT_USER_UID="$(id -u)"
 	DEFAULT_USER_GID="$(id -g)"
+	if [[ ! -e /home/${DEFAULT_USER}/.bashrc ]]; then
+		cp /etc/skel/.* /home/$DEFAULT_USER/
+	fi
 fi
 
 echo "Launched container with user: $DEFAULT_USER, uid: $DEFAULT_USER_UID, gid: $DEFAULT_USER_GID"
+
+cd $HOME
 
 if which "$1" > /dev/null 2>&1 ; then
 	source /opt/ros/${ROS_DISTRO}/setup.bash
@@ -59,4 +67,3 @@ if which "$1" > /dev/null 2>&1 ; then
 else
 	echo $@ | $EXEC $SHELL -li
 fi
-

--- a/galactic/ros_entrypoint.sh
+++ b/galactic/ros_entrypoint.sh
@@ -5,6 +5,7 @@ DEFAULT_USER=${DEFAULT_USER:-'ubuntu'}
 DEFAULT_USER_UID=${USER_UID:-'1000'}
 DEFAULT_USER_GID=${USER_GID:-'1000'}
 NOPASSWD=${NOPASSWD:-''} # set 'NOPASSWD:' to disable asking sudo password
+SHELL=${DEFAULT_SHELL:-$SHELL}
 
 if [[ $(id -u) -eq 0 ]]; then
 	echo "Set disable_coredump false" >> /etc/sudo.conf
@@ -21,8 +22,9 @@ fi
 if [[ $(id -u) -eq 0 ]]; then
 	EXEC="exec /sbin/su-exec ${DEFAULT_USER}"
 
-	# create_user
-	if [[ ! -e /home/${DEFAULT_USER} ]]; then
+	# if the user does not exist, create user
+	if [[ $(id -u ${DEFAULT_USER} 2> /dev/null) != ${DEFAULT_USER_UID} ]]; then
+		echo creating user ${DEFAULT_USER}
 		groupadd -g "${DEFAULT_USER_GID}" "${DEFAULT_USER}"
 		useradd --create-home --home-dir /home/${DEFAULT_USER} --uid ${DEFAULT_USER_UID} --shell /bin/bash \
 		    --gid ${DEFAULT_USER_GID} --groups sudo ${DEFAULT_USER}
@@ -44,14 +46,20 @@ if [[ $(id -u) -eq 0 ]]; then
 
 	DEFAULT_USER_UID="$(${EXEC} id -u)"
 	DEFAULT_USER_GID="$(${EXEC} id -g)"
+	HOME="/home/${DEFAULT_USER}"
 else # use existing user
 	EXEC="exec"
 	DEFAULT_USER="$(whoami)"
 	DEFAULT_USER_UID="$(id -u)"
 	DEFAULT_USER_GID="$(id -g)"
+	if [[ ! -e /home/${DEFAULT_USER}/.bashrc ]]; then
+		cp /etc/skel/.* /home/$DEFAULT_USER/
+	fi
 fi
 
 echo "Launched container with user: $DEFAULT_USER, uid: $DEFAULT_USER_UID, gid: $DEFAULT_USER_GID"
+
+cd $HOME
 
 if which "$1" > /dev/null 2>&1 ; then
 	source /opt/ros/${ROS_DISTRO}/setup.bash
@@ -59,4 +67,3 @@ if which "$1" > /dev/null 2>&1 ; then
 else
 	echo $@ | $EXEC $SHELL -li
 fi
-

--- a/humble/ros_entrypoint.sh
+++ b/humble/ros_entrypoint.sh
@@ -5,6 +5,7 @@ DEFAULT_USER=${DEFAULT_USER:-'ubuntu'}
 DEFAULT_USER_UID=${USER_UID:-'1000'}
 DEFAULT_USER_GID=${USER_GID:-'1000'}
 NOPASSWD=${NOPASSWD:-''} # set 'NOPASSWD:' to disable asking sudo password
+SHELL=${DEFAULT_SHELL:-$SHELL}
 
 if [[ $(id -u) -eq 0 ]]; then
 	echo "Set disable_coredump false" >> /etc/sudo.conf
@@ -21,8 +22,9 @@ fi
 if [[ $(id -u) -eq 0 ]]; then
 	EXEC="exec /sbin/su-exec ${DEFAULT_USER}"
 
-	# create_user
-	if [[ ! -e /home/${DEFAULT_USER} ]]; then
+	# if the user does not exist, create user
+	if [[ $(id -u ${DEFAULT_USER} 2> /dev/null) != ${DEFAULT_USER_UID} ]]; then
+		echo creating user ${DEFAULT_USER}
 		groupadd -g "${DEFAULT_USER_GID}" "${DEFAULT_USER}"
 		useradd --create-home --home-dir /home/${DEFAULT_USER} --uid ${DEFAULT_USER_UID} --shell /bin/bash \
 		    --gid ${DEFAULT_USER_GID} --groups sudo ${DEFAULT_USER}
@@ -44,14 +46,20 @@ if [[ $(id -u) -eq 0 ]]; then
 
 	DEFAULT_USER_UID="$(${EXEC} id -u)"
 	DEFAULT_USER_GID="$(${EXEC} id -g)"
+	HOME="/home/${DEFAULT_USER}"
 else # use existing user
 	EXEC="exec"
 	DEFAULT_USER="$(whoami)"
 	DEFAULT_USER_UID="$(id -u)"
 	DEFAULT_USER_GID="$(id -g)"
+	if [[ ! -e /home/${DEFAULT_USER}/.bashrc ]]; then
+		cp /etc/skel/.* /home/$DEFAULT_USER/
+	fi
 fi
 
 echo "Launched container with user: $DEFAULT_USER, uid: $DEFAULT_USER_UID, gid: $DEFAULT_USER_GID"
+
+cd $HOME
 
 if which "$1" > /dev/null 2>&1 ; then
 	source /opt/ros/${ROS_DISTRO}/setup.bash
@@ -59,4 +67,3 @@ if which "$1" > /dev/null 2>&1 ; then
 else
 	echo $@ | $EXEC $SHELL -li
 fi
-

--- a/iron/ros_entrypoint.sh
+++ b/iron/ros_entrypoint.sh
@@ -5,6 +5,7 @@ DEFAULT_USER=${DEFAULT_USER:-'ubuntu'}
 DEFAULT_USER_UID=${USER_UID:-'1000'}
 DEFAULT_USER_GID=${USER_GID:-'1000'}
 NOPASSWD=${NOPASSWD:-''} # set 'NOPASSWD:' to disable asking sudo password
+SHELL=${DEFAULT_SHELL:-$SHELL}
 
 if [[ $(id -u) -eq 0 ]]; then
 	echo "Set disable_coredump false" >> /etc/sudo.conf
@@ -21,8 +22,9 @@ fi
 if [[ $(id -u) -eq 0 ]]; then
 	EXEC="exec /sbin/su-exec ${DEFAULT_USER}"
 
-	# create_user
-	if [[ ! -e /home/${DEFAULT_USER} ]]; then
+	# if the user does not exist, create user
+	if [[ $(id -u ${DEFAULT_USER} 2> /dev/null) != ${DEFAULT_USER_UID} ]]; then
+		echo creating user ${DEFAULT_USER}
 		groupadd -g "${DEFAULT_USER_GID}" "${DEFAULT_USER}"
 		useradd --create-home --home-dir /home/${DEFAULT_USER} --uid ${DEFAULT_USER_UID} --shell /bin/bash \
 		    --gid ${DEFAULT_USER_GID} --groups sudo ${DEFAULT_USER}
@@ -44,14 +46,20 @@ if [[ $(id -u) -eq 0 ]]; then
 
 	DEFAULT_USER_UID="$(${EXEC} id -u)"
 	DEFAULT_USER_GID="$(${EXEC} id -g)"
+	HOME="/home/${DEFAULT_USER}"
 else # use existing user
 	EXEC="exec"
 	DEFAULT_USER="$(whoami)"
 	DEFAULT_USER_UID="$(id -u)"
 	DEFAULT_USER_GID="$(id -g)"
+	if [[ ! -e /home/${DEFAULT_USER}/.bashrc ]]; then
+		cp /etc/skel/.* /home/$DEFAULT_USER/
+	fi
 fi
 
 echo "Launched container with user: $DEFAULT_USER, uid: $DEFAULT_USER_UID, gid: $DEFAULT_USER_GID"
+
+cd $HOME
 
 if which "$1" > /dev/null 2>&1 ; then
 	source /opt/ros/${ROS_DISTRO}/setup.bash
@@ -59,4 +67,3 @@ if which "$1" > /dev/null 2>&1 ; then
 else
 	echo $@ | $EXEC $SHELL -li
 fi
-

--- a/jazzy/ros_entrypoint.sh
+++ b/jazzy/ros_entrypoint.sh
@@ -5,6 +5,7 @@ DEFAULT_USER=${DEFAULT_USER:-'ubuntu'}
 DEFAULT_USER_UID=${USER_UID:-'1000'}
 DEFAULT_USER_GID=${USER_GID:-'1000'}
 NOPASSWD=${NOPASSWD:-''} # set 'NOPASSWD:' to disable asking sudo password
+SHELL=${DEFAULT_SHELL:-$SHELL}
 
 if [[ $(id -u) -eq 0 ]]; then
 	echo "Set disable_coredump false" >> /etc/sudo.conf
@@ -21,8 +22,9 @@ fi
 if [[ $(id -u) -eq 0 ]]; then
 	EXEC="exec /sbin/su-exec ${DEFAULT_USER}"
 
-	# create_user
-	if [[ ! -e /home/${DEFAULT_USER} ]]; then
+	# if the user does not exist, create user
+	if [[ $(id -u ${DEFAULT_USER} 2> /dev/null) != ${DEFAULT_USER_UID} ]]; then
+		echo creating user ${DEFAULT_USER}
 		groupadd -g "${DEFAULT_USER_GID}" "${DEFAULT_USER}"
 		useradd --create-home --home-dir /home/${DEFAULT_USER} --uid ${DEFAULT_USER_UID} --shell /bin/bash \
 		    --gid ${DEFAULT_USER_GID} --groups sudo ${DEFAULT_USER}
@@ -44,14 +46,20 @@ if [[ $(id -u) -eq 0 ]]; then
 
 	DEFAULT_USER_UID="$(${EXEC} id -u)"
 	DEFAULT_USER_GID="$(${EXEC} id -g)"
+	HOME="/home/${DEFAULT_USER}"
 else # use existing user
 	EXEC="exec"
 	DEFAULT_USER="$(whoami)"
 	DEFAULT_USER_UID="$(id -u)"
 	DEFAULT_USER_GID="$(id -g)"
+	if [[ ! -e /home/${DEFAULT_USER}/.bashrc ]]; then
+		cp /etc/skel/.* /home/$DEFAULT_USER/
+	fi
 fi
 
 echo "Launched container with user: $DEFAULT_USER, uid: $DEFAULT_USER_UID, gid: $DEFAULT_USER_GID"
+
+cd $HOME
 
 if which "$1" > /dev/null 2>&1 ; then
 	source /opt/ros/${ROS_DISTRO}/setup.bash
@@ -59,4 +67,3 @@ if which "$1" > /dev/null 2>&1 ; then
 else
 	echo $@ | $EXEC $SHELL -li
 fi
-


### PR DESCRIPTION
fix `chown: invalid user: ‘ubuntu:ubuntu’`

- https://github.com/Tiryoh/docker-ros/pull/17